### PR TITLE
Update Dockerfile.dazel

### DIFF
--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -1,7 +1,7 @@
 FROM debian:jessie-backports
 MAINTAINER Nadir Izrael nadir.izr@gmail.com
 
-ENV BAZEL_VERSION 0.3.1
+ENV BAZEL_VERSION 0.4.5
 
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/99_norecommends \
  && echo 'APT::AutoRemove::RecommendsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends \


### PR DESCRIPTION
The version of Bazel that Dazel is currently using is incompatible with some popular repositories (e.g. rules_go). Update it to the current latest stable version of Bazel (warning... did not test).