### PR TITLE
[Issue 35] Fix dazel's `PATH` argument management

### DIFF
--- a/dazel.py
+++ b/dazel.py
@@ -240,8 +240,9 @@ class DockerInstance:
         if not os.path.exists(self.dockerfile):
             raise RuntimeError("No Dockerfile to build the dazel image from.")
 
+        dockerfile_directory = os.path.dirname(os.path.realpath(self.dockerfile))
         command = "%s build -t %s/%s -f %s %s" % (
-            self.docker_command, self.repository, self.image_name, self.dockerfile, self.directory)
+            self.docker_command, self.repository, self.image_name, self.dockerfile, dockerfile_directory)
         command = self._with_docker_machine(command)
         return self._run_silent_command(command)
 


### PR DESCRIPTION
This allows Dockerfile directives that reference relative paths to
work. Without it, the `_build` method sets the `PATH` to
`self.directory` which is the bazel workspace. These things are not
necessarily related.

https://github.com/nadirizr/dazel/issues/35