### PR TITLE
Add specifying user as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,8 @@ DAZEL_BAZEL_RC_FILE=""
 # More information on the :delegated flag: https://docs.docker.com/docker-for-mac/osxfs-caching/.
 # NOTE: This will fail on Docker versions < 17.04.
 DAZEL_DELEGATED_VOLUME=True
-```
 
+# The user, in the same format as the --user option docker run and docker exec takes,
+# to use when starting the container and executing commands inside of the container
+DAZEL_USER = ""
+```

--- a/README.rst
+++ b/README.rst
@@ -157,3 +157,7 @@ The possible parameters to set are (with their defaults):
     # More information on the :delegated flag: https://docs.docker.com/docker-for-mac/osxfs-caching/.
     # NOTE: This will fail on Docker versions < 17.04.
     DAZEL_DELEGATED_VOLUME=True
+
+    # The user, in the same format as the --user option docker run and docker exec takes,
+    # to use when starting the container and executing commands inside of the container
+    DAZEL_USER = ""


### PR DESCRIPTION
I have a use case where I want to specify the user that docker run and docker exec use.  I have added support for a DAZEL_USER config value.  If the value is set, it will be given to docker exec and docker run in the -user argument.