### PR TITLE
Add DAZEL_DOCKER_BUILD_ARGS config

### DIFF
--- a/dazel.py
+++ b/dazel.py
@@ -29,6 +29,7 @@ DEFAULT_DOCKER_COMPOSE_COMMAND = "docker-compose"
 DEFAULT_DOCKER_COMPOSE_PROJECT_NAME = "dazel"
 DEFAULT_DOCKER_COMPOSE_SERVICES = ""
 DEFAULT_USER = ""
+DEFAULT_DOCKER_BUILD_ARGS = ""
 
 DEFAULT_DELEGATED_VOLUME = True
 DEFAULT_BAZEL_USER_OUTPUT_ROOT = os.path.expanduser("~/.cache/bazel/_bazel_%s" %
@@ -58,7 +59,7 @@ class DockerInstance:
                        run_deps, docker_compose_file, docker_compose_command,
                        docker_compose_project_name, docker_compose_services, bazel_user_output_root,
                        bazel_rc_file, docker_run_privileged, docker_machine, dazel_run_file,
-                       workspace_hex, delegated_volume, user):
+                       workspace_hex, delegated_volume, user, docker_build_args):
         real_directory = os.path.realpath(directory)
         self.workspace_hex_digest = ""
         self.instance_name = instance_name
@@ -81,6 +82,7 @@ class DockerInstance:
         self.dazel_run_file = dazel_run_file
         self.delegated_volume_flag = ":delegated" if delegated_volume else ""
         self.user = user
+        self.docker_build_args = docker_build_args
 
         if workspace_hex:
             self.workspace_hex_digest = hashlib.md5(real_directory.encode("ascii")).hexdigest()
@@ -136,7 +138,8 @@ class DockerInstance:
                 workspace_hex=config.get("DAZEL_WORKSPACE_HEX",
                                           DEFAULT_WORKSPACE_HEX),
                 delegated_volume=config.get("DAZEL_DELEGATED_VOLUME", "DEFAULT_DELEGATED_VOLUME"),
-                user = config.get("DAZEL_USER", DEFAULT_USER),
+                user=config.get("DAZEL_USER", DEFAULT_USER),
+                docker_build_args=config.get("DAZEL_DOCKER_BUILD_ARGS", DEFAULT_DOCKER_BUILD_ARGS),
         )
 
     def send_command(self, args):
@@ -247,8 +250,8 @@ class DockerInstance:
         if not os.path.exists(self.dockerfile):
             raise RuntimeError("No Dockerfile to build the dazel image from.")
 
-        command = "%s build -t %s/%s -f %s %s" % (
-            self.docker_command, self.repository, self.image_name, self.dockerfile, self.directory)
+        command = "%s build %s -t %s/%s -f %s %s" % (
+            self.docker_command, self.docker_build_args, self.repository, self.image_name, self.dockerfile, self.directory)
         command = self._with_docker_machine(command)
         return self._run_silent_command(command)
 


### PR DESCRIPTION
in order to speedup Dazel image build by using `--cache-from` flag