### PR TITLE
Add BAZEL_BUILD_DIRECTORY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ DAZEL_DOCKERFILE="Dockerfile.dazel"  # in DAZEL_DIRECTORY
 # The repository to pull the dazel image from.
 DAZEL_REPOSITORY="dazel"
 
-# The directory to build the dazel image in.
+# The directory containing the bazel workspace
 DAZEL_DIRECTORY=$PWD
+
+# The directory to build the docker image in
+DAZEL_BUILD_DIRECTORY=$PWD
 
 # The command to run inside the container.
 # NOTE: You should add flags to the .bazelrc file instead of here, since it is

--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,11 @@ The possible parameters to set are (with their defaults):
     # The repository to pull the dazel image from.
     DAZEL_REPOSITORY="dazel"
 
-    # The directory to build the dazel image in.
+    # The directory containing the bazel workspace
     DAZEL_DIRECTORY=$PWD
+
+    # The directory to build the docker image in
+    DAZEL_BUILD_DIRECTORY=$PWD
 
     # The command to run inside the container.
     # NOTE: You should add flags to the .bazelrc file instead of here, since it is

--- a/dazel.py
+++ b/dazel.py
@@ -16,6 +16,7 @@ DEFAULT_IMAGE_NAME = "dazel"
 DEFAULT_RUN_COMMAND = "/bin/bash"
 DEFAULT_DOCKER_COMMAND = "docker"
 DEFAULT_LOCAL_DOCKERFILE = "Dockerfile.dazel"
+DEFAULT_BUILD_DIRECTORY = os.getcwd()
 DEFAULT_REMOTE_REPOSITORY = "dazel"
 DEFAULT_DIRECTORY = os.getcwd()
 DEFAULT_COMMAND = "/usr/bin/bazel"
@@ -55,8 +56,8 @@ class DockerInstance:
     """
 
     def __init__(self, instance_name, image_name, run_command, docker_command, dockerfile,
-                       repository, directory, command, volumes, ports, env_vars, network,
-                       run_deps, docker_compose_file, docker_compose_command,
+                       repository, directory, build_directory, command, volumes, ports,
+                       env_vars, network, run_deps, docker_compose_file, docker_compose_command,
                        docker_compose_project_name, docker_compose_services, bazel_user_output_root,
                        bazel_rc_file, docker_run_privileged, docker_machine, dazel_run_file,
                        workspace_hex, delegated_volume, user, docker_build_args):
@@ -69,6 +70,7 @@ class DockerInstance:
         self.dockerfile = dockerfile
         self.repository = repository
         self.directory = directory
+        self.build_directory = build_directory
         self.command = command
         self.network = network
         self.docker_compose_file = docker_compose_file
@@ -113,6 +115,7 @@ class DockerInstance:
                 dockerfile=config.get("DAZEL_DOCKERFILE", DEFAULT_LOCAL_DOCKERFILE),
                 repository=config.get("DAZEL_REPOSITORY", DEFAULT_REMOTE_REPOSITORY),
                 directory=config.get("DAZEL_DIRECTORY", DEFAULT_DIRECTORY),
+                build_directory=config.get("DAZEL_BUILD_DIRECTORY", DEFAULT_BUILD_DIRECTORY),
                 command=config.get("DAZEL_COMMAND", DEFAULT_COMMAND),
                 volumes=config.get("DAZEL_VOLUMES", DEFAULT_VOLUMES),
                 ports=config.get("DAZEL_PORTS", DEFAULT_PORTS),
@@ -251,7 +254,7 @@ class DockerInstance:
             raise RuntimeError("No Dockerfile to build the dazel image from.")
 
         command = "%s build %s -t %s/%s -f %s %s" % (
-            self.docker_command, self.docker_build_args, self.repository, self.image_name, self.dockerfile, self.directory)
+            self.docker_command, self.docker_build_args, self.repository, self.image_name, self.dockerfile, self.build_directory)
         command = self._with_docker_machine(command)
         return self._run_silent_command(command)
 


### PR DESCRIPTION
It is often useful to limit the Docker build context to a specific
directory to reduce the number of files sent to the daemon and speed
up builds.

Add a BAZEL_BUILD_DIRECTORY option to specify the directory to build
the Docker image in, which does not have to be identical to the
workspace root.