### PR TITLE
Add support to run dazel on windows enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ DAZEL_COMMAND="/usr/bin/bazel"
 # Add any additional volumes you want to share between the host and the docker
 # container, in the normal "hostdir:dockerdir" format.
 # This can be a python iterable, or a comma-separated string.
+# If working on windows add drive name to avoid conflicts, e.g.
+# DAZEL_VOLUMES = ["C:\\tmp:/C/tmp"]
 DAZEL_VOLUMES=[]
 
 # Add any ports you want to publish from the dazel container to the host, in the

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Running the command for the first time will start the container on it's own, and
 You can configure anything you need through the ".dazelrc" file in the same directory.
 Take a look at the configuration section for information on how to write one.
 
+It is also possible to run dazel from Windows environment towards a Posix Docker image. You just need to run dazel from a terminal started as Administrator to be able to create links.
+
 ## Installation
 
 ### Dependencies

--- a/dazel.py
+++ b/dazel.py
@@ -619,7 +619,7 @@ class DockerInstance:
                not os.path.exists(os.path.join(directory, BAZEL_WORKSPACE_FILE))):
             directory = os.path.dirname(directory)
         if not os.path.exists(os.path.join(directory, BAZEL_WORKSPACE_FILE)):
-            raise FileNotFoundError("ERROR: No %s file found!" %BAZEL_WORKSPACE_FILE)
+            raise FileNotFoundError("ERROR: No %s file found!" % BAZEL_WORKSPACE_FILE)
         else:
             return directory
 


### PR DESCRIPTION
Update to run dazel on windows enviroment using
a posix docker image.

Dazel on windows needs to be run as administrator 
to be able to create symlinks, see: https://docs.bazel.build/versions/main/windows.html