### PR TITLE
Add DAZEL_DOCKER_EXEC_ARGS config to dazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 *.pyc
 build/
+.idea


### PR DESCRIPTION
**Motivation**
I need to pass the current user branch and Jenkins build-id as environment variables to Bazel.
The environment variables will be passed from Dazel to Bazel which will persist with `workspace_status`.

CC @Faqa 
Thanks, @mishas (Miss you!)